### PR TITLE
fix: include lowercase proxy vars for cURL

### DIFF
--- a/src/manpages.py
+++ b/src/manpages.py
@@ -193,10 +193,14 @@ class Manpages:
 
         # Iterate over the possible proxy variables, and if a value is set,
         # construct a systemd 'Environment' line and add to the list of lines.
+        # Add both upper and lower case to account for expectations of different applications
+        # e.g. curl only accepts the lower case form of "http_proxy"
+        # https://everything.curl.dev/usingcurl/proxies/env.html#http_proxy-in-lower-case-only
         lines = []
         for v in proxy_vars:
             if proxy := os.environ.get(v[0], None):
                 lines.append(f"\nEnvironment={v[1]}={proxy}")
+                lines.append(f"\nEnvironment={v[1].lower()}={proxy}")
 
         # Template out the unit file and write it to disk.
         env = Environment(loader=FileSystemLoader(Path(__file__).parent.parent / "app" / "config"))

--- a/tests/functional/test_manpages.py
+++ b/tests/functional/test_manpages.py
@@ -70,7 +70,9 @@ def test_install_manpages_with_proxy_config(manpages):
 
     lines = UPDATE_SERVICE_PATH.read_text().splitlines()
 
+    assert "Environment=http_proxy=http://proxy.example.com" in lines
     assert "Environment=HTTP_PROXY=http://proxy.example.com" in lines
+    assert "Environment=https_proxy=https://proxy.example.com" in lines
     assert "Environment=HTTPS_PROXY=https://proxy.example.com" in lines
 
     del os.environ["JUJU_CHARM_HTTP_PROXY"]


### PR DESCRIPTION
Noticed that `update-manpages` was still attempting to connect directly to the archive after #6


  
```bash
ubuntu@juju-b1e18d-stg-ps7-test-machine-model-14:~$ ps auxfww | grep update
ubuntu     15909  0.0  0.0   7080  2048 pts/0    S+   04:51   0:00              \_ grep --color=auto update
www-data   15881  0.0  0.2  97908 10880 ?        S    04:51   0:00  |   \_ curl -s http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/Packages.gz
www-data   15887  0.0  0.2  97908 10752 ?        S    04:51   0:00  |   \_ curl -s http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/Packages.gz
www-data   15856  0.0  0.2  97908 10880 ?        S    04:51   0:00  |   \_ curl -s http://archive.ubuntu.com/ubuntu/dists/oracular-updates/main/binary-amd64/Packages.gz
www-data   15872  0.0  0.2  97908 10624 ?        S    04:51   0:00  |   \_ curl -s http://archive.ubuntu.com/ubuntu/dists/plucky-updates/main/binary-amd64/Packages.gz
www-data   15869  0.0  0.2  97908 10624 ?        S    04:51   0:00      \_ curl -s http://archive.ubuntu.com/ubuntu/dists/questing-updates/main/binary-amd64/Packages.gz

ubuntu@juju-b1e18d-stg-ps7-test-machine-model-14:~$ sudo lsof -i -a -p 15869
COMMAND   PID     USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
curl    15869 www-data    5u  IPv4  37666      0t0  TCP juju-b1e18d-stg-ps7-test-machine-model-14:51312->ubuntu-mirror-1.ps6.canonical.com:http (SYN_SENT)
```

Verified that the proxy vars were passed through as expected:
```bash
ubuntu@juju-b1e18d-stg-ps7-test-machine-model-14:~$ sudo cat /proc/15869/environ
MEMORY_PRESSURE_WRITE=c29tZSAyMDAwMDAgMjAwMDAwMAA=PWD=/LOGNAME=www-dataSYSTEMD_EXEC_PID=15727HOME=/var/wwwLANG=C.UTF-8MEMORY_PRESSURE_WATCH=/sys/fs/cgroup/system.slice/update-manpages.service/memory.pressureINVOCATION_ID=2bd83d8d15ef4e709875d90a0b14f45eMANPAGES_CONFIG_FILE=/app/www/config.jsonUSER=www-dataNO_PROXY=127.0.0.1,localhost,::1,10.151.0.0/16,10.152.0.0/16SHLVL=1HTTPS_PROXY=http://instance-egress.ps7.internal:3128HTTP_PROXY=http://instance-egress.ps7.internal:3128JOURNAL_STREAM=8:37073PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin_=/usr/bin/curl
```

Seems this is an intentional design choice on the part of cURL: https://everything.curl.dev/usingcurl/proxies/env.html#http_proxy-in-lower-case-only