### PR TITLE
fix: disable absolute redirects in manpages nginx config

### DIFF
--- a/app/config/manpages.conf
+++ b/app/config/manpages.conf
@@ -7,6 +7,8 @@ server {
     root /app/www;
     error_page 404 /not_found.html;
 
+    absolute_redirect off;
+    
     location / {
         ssi on;
         index /index_real.html;


### PR DESCRIPTION
By default nginx is using aboslute redirect URLs, so `manpages.example.com/manpages` with no trailing slash (per the "Browse the repository" link on the index page) redirects to `manpages.example.com:8080/manpages/`.

Setting `absolute_redirect off` results in relative URLs, so `manpages.example.com/manpages` becomes `manpages.example.com/manpages/`.
