### PR TITLE
fix: correct spelling of "GitHub"

### DIFF
--- a/app/www/below.html
+++ b/app/www/below.html
@@ -3,7 +3,7 @@
     </div>
     <footer class="p-strip is-shallow">
       <div class="row">
-        <p>Powered by the <a href="https://github.com/canonical/ubuntu-manpages-operator">Ubuntu Manpage Operator</a>, file bugs in <a href="https://github.com/canonical/ubuntu-manpages-operator/issues">Github</a></p>
+        <p>Powered by the <a href="https://github.com/canonical/ubuntu-manpages-operator">Ubuntu Manpage Operator</a>, file bugs in <a href="https://github.com/canonical/ubuntu-manpages-operator/issues">GitHub</a></p>
         <p>&copy; 2025 Canonical. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
       </div>
     </footer>


### PR DESCRIPTION
Use the standard spelling of "GitHub" in the footer that's displayed below each man page.