### PR TITLE
fix(search): rebuild index after ingest via loopback admin endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@
 # MANPAGES_REPOS=main, restricted, universe, multiverse
 # MANPAGES_ARCH=amd64
 # MANPAGES_ADDR=:8080
+# MANPAGES_ADMIN_ADDR=127.0.0.1:9090
 # MANPAGES_LOG_LEVEL=info
 
 # Discard the cache and force a full re-download and re-processing of all manpages.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All three binaries read configuration from environment variables, optionally loa
 | `MANPAGES_REPOS`           | `main, restricted, universe, multiverse`                 | Ubuntu repos to scan                                   |
 | `MANPAGES_ARCH`            | `amd64`                                                  | Architecture to fetch packages for                     |
 | `MANPAGES_ADDR`            | `:8080`                                                  | HTTP bind address (server only)                        |
+| `MANPAGES_ADMIN_ADDR`      | `127.0.0.1:9090`                                         | Admin listener address for internal endpoints; must be loopback-only (server only) |
 | `MANPAGES_LOG_LEVEL`       | `info`                                                   | Log level (debug, info, warn, error)                   |
 | `MANPAGES_FORCE`           | `false`                                                  | Force reprocessing of all packages (ignore SHA1 cache) |
 

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/canonical/ubuntu-manpages-operator/internal/config"
 	"github.com/canonical/ubuntu-manpages-operator/internal/fetcher"
@@ -76,5 +78,21 @@ func ingest(logger *slog.Logger, cfg *config.Config) error {
 	}
 
 	ctx := context.Background()
-	return runner.Run(ctx, cfg.ReleaseKeys())
+	if err := runner.Run(ctx, cfg.ReleaseKeys()); err != nil {
+		return err
+	}
+	notifyReindex(logger, cfg.AdminAddr)
+	return nil
+}
+
+func notifyReindex(logger *slog.Logger, adminAddr string) {
+	url := "http://" + adminAddr + "/_/reindex"
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(url, "", nil)
+	if err != nil {
+		logger.Warn("failed to notify server of reindex", "error", err)
+		return
+	}
+	_ = resp.Body.Close()
+	logger.Info("server notified of reindex", "status", resp.StatusCode)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,7 +29,7 @@ func main() {
 	cfg.ReleaseVersions = versions
 
 	server := web.NewServer(cfg, logger)
-	if err := server.ListenAndServe(cfg.Addr); err != nil {
+	if err := server.ListenAndServe(cfg.Addr, cfg.AdminAddr); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Repos           []string
 	Arch            string
 	Addr            string
+	AdminAddr       string
 	LogLevel        string
 	Force           bool
 }
@@ -39,6 +40,7 @@ func Load() *Config {
 		Repos:         splitCSV(envOrDefault("MANPAGES_REPOS", "main, restricted, universe, multiverse")),
 		Arch:          envOrDefault("MANPAGES_ARCH", "amd64"),
 		Addr:          envOrDefault("MANPAGES_ADDR", ":8080"),
+		AdminAddr:     envOrDefault("MANPAGES_ADMIN_ADDR", "127.0.0.1:9090"),
 		LogLevel:      envOrDefault("MANPAGES_LOG_LEVEL", "info"),
 		Force:         envBool("MANPAGES_FORCE"),
 	}

--- a/internal/search/searcher.go
+++ b/internal/search/searcher.go
@@ -9,6 +9,7 @@ import (
 // search implementation.
 type Searcher interface {
 	Search(ctx context.Context, query, distro, language string, limit, offset int) (SearchResponse, error)
+	Rebuild()
 	Close() error
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"mime"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -192,7 +193,7 @@ func NewServer(cfg *config.Config, logger *slog.Logger) *Server {
 	}
 }
 
-func (s *Server) ListenAndServe(addr string) error {
+func (s *Server) ListenAndServe(addr, adminAddr string) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealth)
 	mux.HandleFunc("/robots.txt", s.handleRobotsTxt)
@@ -214,8 +215,7 @@ func (s *Server) ListenAndServe(addr string) error {
 	sitemapDir := filepath.Join(s.cfg.PublicHTMLDir, "sitemaps")
 	mux.Handle("/sitemaps/", http.StripPrefix("/sitemaps/", http.FileServer(http.Dir(sitemapDir))))
 
-	srv := &http.Server{
-		Addr:              addr,
+	pubSrv := &http.Server{
 		Handler:           s.logRequests(securityHeaders(gzipHandler(mux))),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
@@ -224,8 +224,35 @@ func (s *Server) ListenAndServe(addr string) error {
 		MaxHeaderBytes:    1 << 20, // 1 MB
 	}
 
-	s.logger.Info("listening", "addr", addr)
-	return srv.ListenAndServe()
+	adminMux := http.NewServeMux()
+	adminMux.HandleFunc("POST /_/reindex", s.handleReindex)
+	adminSrv := &http.Server{
+		Handler:           adminMux,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	pubLn, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	adminLn, err := net.Listen("tcp", adminAddr)
+	if err != nil {
+		return err
+	}
+
+	s.logger.Info("listening", "addr", addr, "admin_addr", adminAddr)
+
+	errc := make(chan error, 2)
+	go func() { errc <- pubSrv.Serve(pubLn) }()
+	go func() { errc <- adminSrv.Serve(adminLn) }()
+	return <-errc
+}
+
+func (s *Server) handleReindex(w http.ResponseWriter, r *http.Request) {
+	go s.search.Rebuild()
+	w.WriteHeader(http.StatusAccepted)
 }
 
 func (s *Server) handleSearchPage(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/canonical/ubuntu-manpages-operator/internal/config"
 	"github.com/canonical/ubuntu-manpages-operator/internal/search"
@@ -1111,5 +1112,53 @@ func TestHandleSearchPageNoMatchesShowsTabs(t *testing.T) {
 	// Tabs should still be rendered so the user can switch releases.
 	if !strings.Contains(text, "p-tabs__link") {
 		t.Error("expected release tabs even with no results")
+	}
+}
+
+func TestHandleReindex(t *testing.T) {
+	srv, cfg := testServer(t)
+
+	// Add a new file after the server (and its index) was created, simulating
+	// a file written by ingest after the server started.
+	manDir := filepath.Join(cfg.PublicHTMLDir, "manpages", "noble", "man1")
+	fragment := `<!--META:{"title":"htop","description":"interactive process viewer"}-->` + "\n" + `<p>content</p>`
+	if err := os.WriteFile(filepath.Join(manDir, "htop.1.html"), []byte(fragment), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The index is stale — htop should not be found yet.
+	ctx := t.Context()
+	results, err := srv.search.Search(ctx, "htop", "noble", "", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results.Results) != 0 {
+		t.Fatalf("expected 0 results before reindex, got %d", len(results.Results))
+	}
+
+	// POST /_/reindex should return 202 Accepted.
+	req := httptest.NewRequest(http.MethodPost, "/_/reindex", nil)
+	w := httptest.NewRecorder()
+	srv.handleReindex(w, req)
+
+	if w.Result().StatusCode != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Result().StatusCode)
+	}
+
+	// Rebuild runs in a goroutine; poll briefly until the index is updated.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		results, err = srv.search.Search(ctx, "htop", "noble", "", 10, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results.Results) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if len(results.Results) == 0 {
+		t.Error("expected htop to appear in search results after reindex")
 	}
 }


### PR DESCRIPTION
The search index was built once at server startup, before ingest had written any manpages to disk. Add a POST /_/reindex endpoint on a loopback-only listener (MANPAGES_ADMIN_ADDR, default 127.0.0.1:9090) that triggers Rebuild() asynchronously. The ingest binary calls this endpoint after a successful run, keeping the index current without requiring a server restart.

Fixes #52 