### PR TITLE
fix(web): redirect old /en/ language prefix URLs to canonical paths

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -692,6 +692,18 @@ func (s *Server) handleManpages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Redirect old /en/ language prefix to the canonical (unprefixed) path.
+	// English manpages are stored without a language directory.
+	if len(parts) >= 4 && (parts[3] == "en" || strings.HasPrefix(parts[3], "en/")) {
+		rest := strings.TrimPrefix(parts[3], "en")
+		dest := s.basePath + "/manpages/" + parts[2] + rest
+		if strings.HasSuffix(r.URL.Path, "/") && !strings.HasSuffix(dest, "/") {
+			dest += "/"
+		}
+		http.Redirect(w, r, dest, http.StatusMovedPermanently)
+		return
+	}
+
 	fsPath := filepath.Join(s.cfg.PublicHTMLDir, clean)
 
 	// Serve plain text version of manpages for LLM consumption.

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -917,6 +917,49 @@ func TestLatestRedirectDirectory(t *testing.T) {
 	}
 }
 
+func TestEnglishLanguagePrefixRedirect(t *testing.T) {
+	srv, _ := testServer(t)
+
+	tests := []struct {
+		name    string
+		path    string
+		wantLoc string
+	}{
+		{
+			name:    "manpage with en prefix",
+			path:    "/manpages/noble/en/man1/ls.1.html",
+			wantLoc: "/manpages/noble/man1/ls.1.html",
+		},
+		{
+			name:    "directory with en prefix",
+			path:    "/manpages/noble/en/man1/",
+			wantLoc: "/manpages/noble/man1/",
+		},
+		{
+			name:    "bare en directory",
+			path:    "/manpages/noble/en/",
+			wantLoc: "/manpages/noble/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			w := httptest.NewRecorder()
+			srv.handleManpages(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusMovedPermanently {
+				t.Fatalf("expected 301, got %d", resp.StatusCode)
+			}
+			loc := resp.Header.Get("Location")
+			if loc != tt.wantLoc {
+				t.Errorf("expected redirect to %s, got: %s", tt.wantLoc, loc)
+			}
+		})
+	}
+}
+
 func TestGroupSearchResultsUnknownDistro(t *testing.T) {
 	results := []search.Result{
 		{Title: "foo", Path: "/manpages/unknown/man1/foo.1.html", Distro: "unknown", Section: 1},


### PR DESCRIPTION
Closes #55 — the old site served English manpages under /manpages/{release}/en/man{N}/ but the new site stores them without a language prefix. Add a 301 redirect to maintain backward compatibility for existing links.