### PR TITLE
feat: detect and report disk space errors

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"time"
 
+	"errors"
+	"path/filepath"
+
 	"github.com/canonical/ubuntu-manpages-operator/internal/config"
 	"github.com/canonical/ubuntu-manpages-operator/internal/fetcher"
 	"github.com/canonical/ubuntu-manpages-operator/internal/launchpad"
@@ -66,10 +69,14 @@ func ingest(logger *slog.Logger, cfg *config.Config) error {
 		Logger:       logger,
 		FailuresDir:  cfg.PublicHTMLDir,
 		ForceProcess: cfg.Force,
+		StoragePath:  filepath.Join(cfg.PublicHTMLDir, "manpages"),
 	}
 
 	ctx := context.Background()
 	if err := runner.Run(ctx, cfg.ReleaseKeys()); err != nil {
+		if errors.Is(err, pipeline.ErrDiskFull) {
+			logger.Error("skipping reindex and sitemap generation due to low disk space")
+		}
 		return err
 	}
 	notifyReindex(logger, cfg.AdminAddr)

--- a/internal/pipeline/diskspace.go
+++ b/internal/pipeline/diskspace.go
@@ -1,0 +1,21 @@
+package pipeline
+
+import (
+	"errors"
+	"syscall"
+)
+
+const minFreeBytes = 100 << 20 // 100 MiB
+
+// ErrDiskFull is returned when the storage filesystem has less than 100 MiB available.
+var ErrDiskFull = errors.New("low disk space on manpages storage")
+
+// DiskFull reports whether the filesystem containing path has less than 100 MiB available.
+func DiskFull(path string) bool {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return false // if we can't check, assume OK
+	}
+	avail := stat.Bavail * uint64(stat.Bsize)
+	return avail < minFreeBytes
+}

--- a/internal/pipeline/diskspace_test.go
+++ b/internal/pipeline/diskspace_test.go
@@ -1,0 +1,20 @@
+package pipeline
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDiskFull_NormalFilesystem(t *testing.T) {
+	// A normal filesystem should have well over 100 MiB free.
+	if DiskFull(os.TempDir()) {
+		t.Error("DiskFull reported true on a normal filesystem")
+	}
+}
+
+func TestDiskFull_NonExistentPath(t *testing.T) {
+	// Non-existent path should return false (assume OK).
+	if DiskFull("/nonexistent/path/that/does/not/exist") {
+		t.Error("DiskFull reported true for a non-existent path")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -25,6 +25,7 @@ type Runner struct {
 	Logger           *slog.Logger
 	FailuresDir      string
 	ForceProcess     bool
+	StoragePath      string // checked for available disk space per package
 
 	mu              sync.Mutex
 	statuses        []ReleaseStatus
@@ -42,6 +43,9 @@ func (r *Runner) Run(ctx context.Context, releases []string) error {
 		r.statuses[i] = ReleaseStatus{Release: rel, Stage: "waiting"}
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var wg sync.WaitGroup
 	var firstErr error
 	var errOnce sync.Once
@@ -52,6 +56,9 @@ func (r *Runner) Run(ctx context.Context, releases []string) error {
 			defer wg.Done()
 			if err := r.runRelease(ctx, idx, rel); err != nil {
 				errOnce.Do(func() { firstErr = err })
+				if errors.Is(err, ErrDiskFull) {
+					cancel()
+				}
 				r.mu.Lock()
 				r.statuses[idx].Stage = "error"
 				r.mu.Unlock()
@@ -116,7 +123,15 @@ func (r *Runner) runRelease(ctx context.Context, idx int, release string) error 
 	r.statuses[idx].Total = len(packages)
 	r.mu.Unlock()
 
-	for _, pkg := range packages {
+	for i, pkg := range packages {
+		if ctx.Err() != nil {
+			r.Logger.Error("release cancelled", "release", release, "remaining", len(packages)-i)
+			return ctx.Err()
+		}
+		if r.StoragePath != "" && DiskFull(r.StoragePath) {
+			r.Logger.Error("disk full, stopping ingest", "release", release, "remaining", len(packages)-i)
+			return fmt.Errorf("ingest %s: %w", release, ErrDiskFull)
+		}
 		if err := r.processPackage(ctx, idx, release, pkg, &relFetcher, extractor); err != nil {
 			r.recordFailure(idx, "package", pkg.Name, err)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"github.com/canonical/ubuntu-manpages-operator/internal/config"
+	"github.com/canonical/ubuntu-manpages-operator/internal/pipeline"
 	"github.com/canonical/ubuntu-manpages-operator/internal/search"
 	"github.com/canonical/ubuntu-manpages-operator/internal/sitemap"
 	"github.com/canonical/ubuntu-manpages-operator/internal/transform"
@@ -235,6 +236,7 @@ func (s *Server) ListenAndServe(addr, adminAddr string) error {
 	}
 
 	adminMux := http.NewServeMux()
+	adminMux.HandleFunc("GET /_/healthz", s.handleAdminHealth)
 	adminMux.HandleFunc("POST /_/reindex", s.handleReindex)
 	adminMux.HandleFunc("POST /_/regenerate-sitemaps", s.handleRegenerateSitemaps)
 	adminSrv := &http.Server{
@@ -411,6 +413,21 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleAdminHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	storagePath := filepath.Join(s.cfg.PublicHTMLDir, "manpages")
+	if pipeline.DiskFull(storagePath) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"status": "error",
+			"error":  "low disk space on manpages storage",
+		})
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-manpages
-version: 0.2.0
+version: 0.3.0
 license: Apache-2.0
 base: ubuntu@24.04
 build-base: ubuntu@24.04

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,6 +25,8 @@ class ManpagesCharm(ops.CharmBase):
         self._manpages = Manpages(self._container)
 
         framework.observe(self.on.manpages_pebble_ready, self._on_manpages_pebble_ready)
+        framework.observe(self.on.manpages_pebble_check_failed, self._on_pebble_check_failed)
+        framework.observe(self.on.manpages_pebble_check_recovered, self._on_pebble_check_recovered)
         framework.observe(self.on.update_status, self._on_update_status)
         framework.observe(self.on.update_manpages_action, self._on_config_changed)
         framework.observe(self.on.config_changed, self._on_config_changed)
@@ -76,6 +78,17 @@ class ManpagesCharm(ops.CharmBase):
                 "Failed to connect to workload container. Check `juju debug-log` for details."
             )
             return
+
+    def _on_pebble_check_failed(self, event: ops.PebbleCheckFailedEvent):
+        """Handle a Pebble health check failure."""
+        if event.info.name == "ready":
+            error_msg = self._manpages.get_health_error()
+            self.unit.status = ops.MaintenanceStatus(error_msg)
+
+    def _on_pebble_check_recovered(self, event: ops.PebbleCheckRecoveredEvent):
+        """Handle a Pebble health check recovery."""
+        if event.info.name == "ready":
+            self.unit.status = ops.ActiveStatus()
 
     def _on_update_status(self, _):
         """Update status."""

--- a/src/manpages.py
+++ b/src/manpages.py
@@ -82,7 +82,7 @@ class Manpages:
                     "ready": {
                         "override": "replace",
                         "level": "ready",
-                        "period": "1m",
+                        "period": "30s",
                         "http": {"url": f"http://localhost:{ADMIN_PORT}/_/healthz"},
                         "startup": "enabled",
                     },

--- a/src/manpages.py
+++ b/src/manpages.py
@@ -3,9 +3,12 @@
 
 """Representation of the manpages service."""
 
+import json
 import logging
 import os
 import re
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import ops
@@ -15,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 WWW_DIR = Path("/app") / "www"
 PORT = 8080
+ADMIN_PORT = 9090
 
 # Used to fetch release codenames from the config string passed to the charm.
 RELEASES_PATTERN = re.compile(r"([a-z]+)(?:[,][ ]*)*")
@@ -75,6 +79,13 @@ class Manpages:
                         "tcp": {"port": PORT},
                         "startup": "enabled",
                     },
+                    "ready": {
+                        "override": "replace",
+                        "level": "ready",
+                        "period": "1m",
+                        "http": {"url": f"http://localhost:{ADMIN_PORT}/_/healthz"},
+                        "startup": "enabled",
+                    },
                 },
             }
         )
@@ -124,6 +135,19 @@ class Manpages:
             except (ProtocolError, ConnectionError, PathError, APIError) as e:
                 logger.error("failed to remove manpages for '%s': %s", release, e)
                 raise
+
+    def get_health_error(self) -> str:
+        """Query the admin healthz endpoint for the specific error."""
+        try:
+            resp = urllib.request.urlopen(f"http://localhost:{ADMIN_PORT}/_/healthz", timeout=5)
+            data = json.loads(resp.read())
+            return data.get("error", "unhealthy")
+        except urllib.error.HTTPError as e:
+            # 503 response — read the JSON body for the error detail.
+            data = json.loads(e.read())
+            return data.get("error", "unhealthy")
+        except Exception:
+            return "health check failed"
 
     @property
     def updating(self) -> bool:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,10 +7,12 @@ These tests only cover those methods that do not require internet access,
 and do not attempt to manipulate the underlying machine.
 """
 
+from unittest.mock import patch
+
 import pytest
 from ops import BlockedStatus
-from ops.pebble import Layer, ServiceStatus
-from ops.testing import ActiveStatus, Context, MaintenanceStatus, State, TCPPort
+from ops.pebble import CheckLevel, CheckStatus, Layer, ServiceStatus
+from ops.testing import ActiveStatus, CheckInfo, Context, MaintenanceStatus, State, TCPPort
 from scenario import Container
 
 from charm import ManpagesCharm
@@ -43,9 +45,11 @@ def test_manpages_pebble_ready(loaded_ctx):
 
     result = ctx.run(ctx.on.pebble_ready(container=container), state)
 
-    assert result.get_container("manpages").layers["manpages"] == manpages.pebble_layer(
-        "noble", "http://192.0.2.0:8080"
-    )
+    layer = manpages.pebble_layer("noble", "http://192.0.2.0:8080")
+    assert result.get_container("manpages").layers["manpages"] == layer
+    checks = layer.checks
+    assert "ready" in checks
+    assert checks["ready"].http == {"url": "http://localhost:9090/_/healthz"}
     assert result.get_container("manpages").service_statuses == {
         "manpages": ServiceStatus.ACTIVE,
         "ingest": ServiceStatus.ACTIVE,
@@ -135,3 +139,96 @@ def test_manpages_update_status_not_updating(loaded_ctx):
     result = ctx.run(ctx.on.update_status(), state)
 
     assert result.unit_status == ActiveStatus()
+
+
+CHECKS_LAYER = Layer(
+    {
+        "checks": {
+            "up": {
+                "override": "replace",
+                "level": "alive",
+                "period": "30s",
+                "tcp": {"port": 8080},
+                "startup": "enabled",
+                "threshold": 3,
+            },
+            "ready": {
+                "override": "replace",
+                "level": "ready",
+                "period": "1m",
+                "http": {"url": "http://localhost:9090/_/healthz"},
+                "startup": "enabled",
+                "threshold": 3,
+            },
+        },
+    }
+)
+
+
+@patch("manpages.Manpages.get_health_error", return_value="low disk space on manpages storage")
+def test_pebble_check_failed_disk_full(mock_health, charm):
+    ctx = Context(charm)
+    check_info = CheckInfo(
+        "ready",
+        level=CheckLevel.READY,
+        failures=3,
+        status=CheckStatus.DOWN,
+        threshold=3,
+    )
+    container = Container(
+        name="manpages",
+        can_connect=True,
+        layers={"manpages": CHECKS_LAYER},
+        check_infos={check_info},
+    )
+    state = State(containers=[container], config={"releases": "noble"})
+
+    result = ctx.run(ctx.on.pebble_check_failed(container, info=check_info), state)
+
+    assert result.unit_status == MaintenanceStatus("low disk space on manpages storage")
+
+
+def test_pebble_check_recovered(charm):
+    ctx = Context(charm)
+    check_info = CheckInfo(
+        "ready",
+        level=CheckLevel.READY,
+        status=CheckStatus.UP,
+        threshold=3,
+    )
+    container = Container(
+        name="manpages",
+        can_connect=True,
+        layers={"manpages": CHECKS_LAYER},
+        check_infos={check_info},
+    )
+    state = State(containers=[container], config={"releases": "noble"})
+
+    result = ctx.run(ctx.on.pebble_check_recovered(container, info=check_info), state)
+
+    assert result.unit_status == ActiveStatus()
+
+
+@patch("manpages.Manpages.get_health_error", return_value="low disk space on manpages storage")
+def test_pebble_check_failed_ignores_other_checks(mock_health, charm):
+    """Only the 'ready' check should trigger MaintenanceStatus."""
+    ctx = Context(charm)
+    check_info = CheckInfo(
+        "up",
+        level=CheckLevel.ALIVE,
+        failures=3,
+        status=CheckStatus.DOWN,
+        threshold=3,
+    )
+    container = Container(
+        name="manpages",
+        can_connect=True,
+        layers={"manpages": CHECKS_LAYER},
+        check_infos={check_info},
+    )
+    state = State(containers=[container], config={"releases": "noble"})
+
+    result = ctx.run(ctx.on.pebble_check_failed(container, info=check_info), state)
+
+    # Status should NOT be changed for the 'up' check.
+    assert result.unit_status != MaintenanceStatus("low disk space on manpages storage")


### PR DESCRIPTION
When the manpages storage volume fills up during ingestion, the `ingest` binary keeps churning through thousands of packages — every one failing with `ENOSPC` — wasting time and flooding the logs. The charm has no visibility into this condition and continues to report `ActiveStatus`.

**Go application:**
- Add a `DiskFull()` helper using `syscall.Statfs` that triggers when available space drops below 100 MiB
- Check disk space before processing each package in the pipeline — if low, log at ERROR level and stop immediately
- Cancel all concurrent release goroutines via context cancellation so the entire ingest halts promptly
- Skip reindex and sitemap generation when disk space is low (they write data too)
- Add a `GET /_/healthz` endpoint on the admin mux (port 9090) that returns `200 {"status":"ok"}` or `503 {"status":"error","error":"low disk space on manpages storage"}` — auto-heals when space is freed

**Charm:**
- Add a Pebble HTTP health check (`ready`) that polls the admin `/_/healthz` endpoint every 60s
- Observe `pebble_check_failed` / `pebble_check_recovered` events
- On failure, query the admin healthz for the specific error and set `MaintenanceStatus` with the message
- On recovery, restore `ActiveStatus`
