### PR TITLE
fix(charm): preserve workload health errors and avoid K8s endpoint re…

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,6 @@ class ManpagesCharm(ops.CharmBase):
 
     def _on_config_changed(self, _):
         """Update configuration and fetch relevant manpages."""
-        self.unit.status = ops.MaintenanceStatus("Updating configuration")
         self._replan_workload()
 
     def _replan_workload(self):
@@ -69,7 +68,6 @@ class ManpagesCharm(ops.CharmBase):
             )
             return
 
-        self.unit.status = ops.MaintenanceStatus("Updating manpages")
         try:
             self._manpages.update_manpages(str(self.config["releases"]))
         except (ProtocolError, ConnectionError, APIError) as e:
@@ -79,11 +77,13 @@ class ManpagesCharm(ops.CharmBase):
             )
             return
 
+        self.unit.status = self._compute_status()
+
     def _on_pebble_check_failed(self, event: ops.PebbleCheckFailedEvent):
         """Handle a Pebble health check failure."""
         if event.info.name == "ready":
-            error_msg = self._manpages.get_health_error()
-            self.unit.status = ops.MaintenanceStatus(error_msg)
+            if err := self._manpages.health_error():
+                self.unit.status = ops.MaintenanceStatus(err)
 
     def _on_pebble_check_recovered(self, event: ops.PebbleCheckRecoveredEvent):
         """Handle a Pebble health check recovery."""
@@ -92,10 +92,15 @@ class ManpagesCharm(ops.CharmBase):
 
     def _on_update_status(self, _):
         """Update status."""
+        self.unit.status = self._compute_status()
+
+    def _compute_status(self) -> ops.StatusBase:
+        """Resolve the unit status from workload health and ingestion state."""
+        if err := self._manpages.health_error():
+            return ops.MaintenanceStatus(err)
         if self._manpages.updating:
-            self.unit.status = ops.MaintenanceStatus("Updating manpages")
-        else:
-            self.unit.status = ops.ActiveStatus()
+            return ops.MaintenanceStatus("Updating manpages")
+        return ops.ActiveStatus()
 
     def _get_external_url(self) -> str:
         """Report URL to access Ubuntu Manpages."""

--- a/src/manpages.py
+++ b/src/manpages.py
@@ -81,7 +81,6 @@ class Manpages:
                     },
                     "ready": {
                         "override": "replace",
-                        "level": "ready",
                         "period": "30s",
                         "http": {"url": f"http://localhost:{ADMIN_PORT}/_/healthz"},
                         "startup": "enabled",
@@ -136,7 +135,19 @@ class Manpages:
                 logger.error("failed to remove manpages for '%s': %s", release, e)
                 raise
 
-    def get_health_error(self) -> str:
+    def health_error(self):
+        """Return the ready-check error message if it is currently failing, else None."""
+        try:
+            checks = self.container.get_checks("ready")
+        except (ProtocolError, ConnectionError, APIError, ops.ModelError) as e:
+            logger.error("failed to query pebble checks: %s", e)
+            return None
+        ready = checks.get("ready")
+        if ready is None or ready.status == ops.pebble.CheckStatus.UP:
+            return None
+        return self._fetch_health_error()
+
+    def _fetch_health_error(self) -> str:
         """Query the admin healthz endpoint for the specific error."""
         try:
             resp = urllib.request.urlopen(f"http://localhost:{ADMIN_PORT}/_/healthz", timeout=5)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -154,7 +154,6 @@ CHECKS_LAYER = Layer(
             },
             "ready": {
                 "override": "replace",
-                "level": "ready",
                 "period": "1m",
                 "http": {"url": "http://localhost:9090/_/healthz"},
                 "startup": "enabled",
@@ -165,12 +164,12 @@ CHECKS_LAYER = Layer(
 )
 
 
-@patch("manpages.Manpages.get_health_error", return_value="low disk space on manpages storage")
+@patch("manpages.Manpages._fetch_health_error", return_value="low disk space on manpages storage")
 def test_pebble_check_failed_disk_full(mock_health, charm):
     ctx = Context(charm)
     check_info = CheckInfo(
         "ready",
-        level=CheckLevel.READY,
+        level=CheckLevel.UNSET,
         failures=3,
         status=CheckStatus.DOWN,
         threshold=3,
@@ -192,7 +191,7 @@ def test_pebble_check_recovered(charm):
     ctx = Context(charm)
     check_info = CheckInfo(
         "ready",
-        level=CheckLevel.READY,
+        level=CheckLevel.UNSET,
         status=CheckStatus.UP,
         threshold=3,
     )
@@ -209,7 +208,7 @@ def test_pebble_check_recovered(charm):
     assert result.unit_status == ActiveStatus()
 
 
-@patch("manpages.Manpages.get_health_error", return_value="low disk space on manpages storage")
+@patch("manpages.Manpages._fetch_health_error", return_value="low disk space on manpages storage")
 def test_pebble_check_failed_ignores_other_checks(mock_health, charm):
     """Only the 'ready' check should trigger MaintenanceStatus."""
     ctx = Context(charm)
@@ -232,3 +231,76 @@ def test_pebble_check_failed_ignores_other_checks(mock_health, charm):
 
     # Status should NOT be changed for the 'up' check.
     assert result.unit_status != MaintenanceStatus("low disk space on manpages storage")
+
+
+@patch("manpages.Manpages._fetch_health_error", return_value="low disk space on manpages storage")
+def test_update_status_preserves_health_error(mock_health, charm):
+    """update_status must not clobber a failing ready check with ActiveStatus."""
+    ctx = Context(charm)
+    check_info = CheckInfo(
+        "ready",
+        level=CheckLevel.UNSET,
+        failures=3,
+        status=CheckStatus.DOWN,
+        threshold=3,
+    )
+    container = Container(
+        name="manpages",
+        can_connect=True,
+        layers={"manpages": CHECKS_LAYER},
+        check_infos={check_info},
+        service_statuses={"ingest": ServiceStatus.INACTIVE},
+    )
+    state = State(containers=[container], config={"releases": "noble"})
+
+    result = ctx.run(ctx.on.update_status(), state)
+
+    assert result.unit_status == MaintenanceStatus("low disk space on manpages storage")
+
+
+@patch("manpages.Manpages._fetch_health_error", return_value="low disk space on manpages storage")
+def test_update_status_preserves_health_error_over_updating(mock_health, charm):
+    """A failing health check is more informative than 'Updating manpages'."""
+    ctx = Context(charm)
+    check_info = CheckInfo(
+        "ready",
+        level=CheckLevel.UNSET,
+        failures=3,
+        status=CheckStatus.DOWN,
+        threshold=3,
+    )
+    container = Container(
+        name="manpages",
+        can_connect=True,
+        layers={"manpages": CHECKS_LAYER},
+        check_infos={check_info},
+        service_statuses={"ingest": ServiceStatus.ACTIVE},
+    )
+    state = State(containers=[container], config={"releases": "noble"})
+
+    result = ctx.run(ctx.on.update_status(), state)
+
+    assert result.unit_status == MaintenanceStatus("low disk space on manpages storage")
+
+
+def test_update_status_active_when_ready_up(charm):
+    """Regression guard: with ready UP and ingest inactive, status is Active."""
+    ctx = Context(charm)
+    check_info = CheckInfo(
+        "ready",
+        level=CheckLevel.UNSET,
+        status=CheckStatus.UP,
+        threshold=3,
+    )
+    container = Container(
+        name="manpages",
+        can_connect=True,
+        layers={"manpages": CHECKS_LAYER},
+        check_infos={check_info},
+        service_statuses={"ingest": ServiceStatus.INACTIVE},
+    )
+    state = State(containers=[container], config={"releases": "noble"})
+
+    result = ctx.run(ctx.on.update_status(), state)
+
+    assert result.unit_status == ActiveStatus()


### PR DESCRIPTION
The 'ready' pebble check was declared with level: "ready", which Juju
maps to a Kubernetes readiness probe. A failing readiness probe causes
the pod to be removed from Service endpoints and stops all traffic —
even though the manpages server can still serve already-ingested
content when the disk-space guard trips. Drop the level so the check is
a pure Pebble check: pebble_check_failed/recovered events still fire,
but nothing is wired to a K8s probe.

The failure status set by _on_pebble_check_failed was also being
clobbered on the next update_status/replan tick, since both handlers
unconditionally overwrote the unit status. Route both paths through a
new _compute_status() helper that consults the ready check's state
first, so a failing check stays visible until it recovers.

Rename the HTTP primitive to _fetch_health_error and expose
health_error() (str | None, driven by Pebble's check state) as the
single public entry point.