### PR TITLE
feat: add workshop config for charm + Go dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ scripts/
 
 # Config file
 .env
+
+# Workshop runtime lock
+.workshop.lock

--- a/.workshop/manpages-dev/hooks/check-health
+++ b/.workshop/manpages-dev/hooks/check-health
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Healthy when `go`, `uv`, `make`, and `mandoc` are on PATH and the charm
+# package imports in the synced venv. Run as workshop, not root, to match
+# the environment the actions actually use.
+if sudo -H -i -u workshop -- bash -c \
+    'command -v go >/dev/null \
+        && command -v uv >/dev/null \
+        && command -v make >/dev/null \
+        && command -v mandoc >/dev/null \
+        && cd /project \
+        && PYTHONPATH=/project:/project/lib:/project/src \
+            uv run python -c "import charm"'
+then
+    workshopctl set-health okay
+else
+    workshopctl set-health --code="manpages-env-broken" error
+fi

--- a/.workshop/manpages-dev/hooks/check-health
+++ b/.workshop/manpages-dev/hooks/check-health
@@ -2,16 +2,29 @@
 # Healthy when `go`, `uv`, `make`, and `mandoc` are on PATH and the charm
 # package imports in the synced venv. Run as workshop, not root, to match
 # the environment the actions actually use.
-if sudo -H -i -u workshop -- bash -c \
-    'command -v go >/dev/null \
-        && command -v uv >/dev/null \
-        && command -v make >/dev/null \
-        && command -v mandoc >/dev/null \
-        && cd /project \
-        && PYTHONPATH=/project:/project/lib:/project/src \
-            uv run python -c "import charm"'
-then
-    workshopctl set-health okay
-else
-    workshopctl set-health --code="manpages-env-broken" error
+#
+# On failure, report which specific check tripped so the user knows whether
+# to re-run setup-base (missing tool), setup-project (broken venv), or file
+# a bug (something stranger).
+missing=()
+for tool in go uv make mandoc; do
+    if ! sudo -H -i -u workshop -- command -v "$tool" >/dev/null 2>&1; then
+        missing+=("$tool")
+    fi
+done
+
+if [ ${#missing[@]} -ne 0 ]; then
+    workshopctl set-health --code="manpages-tools-missing" error \
+        "missing tool(s) on PATH for workshop user: ${missing[*]} (re-run 'workshop refresh dev' to reinstall)"
+    exit 0
 fi
+
+import_err=$(sudo -H -i -u workshop -- bash -c \
+    'cd /project && PYTHONPATH=/project:/project/lib:/project/src uv run python -c "import charm"' 2>&1)
+if [ $? -ne 0 ]; then
+    workshopctl set-health --code="manpages-charm-import-failed" error \
+        "charm package failed to import in the workshop venv (uv sync may be stale); first error: ${import_err##*$'\n'}"
+    exit 0
+fi
+
+workshopctl set-health okay

--- a/.workshop/manpages-dev/hooks/setup-base
+++ b/.workshop/manpages-dev/hooks/setup-base
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# Install OS packages the workshop actions need.
+#
+# - mandoc: the Go ingest pipeline shells out to `mandoc` to convert roff
+#   manpages to HTML. The unit tests don't exec it, but `workshop shell` /
+#   `ingest` / `ingest-pkg` runs are unusable without it, and it's cheap.
+# - make: drives the `lint` / `format` / `unit` / `integration` targets.
+# - git: charmcraft's uv plugin and the `git describe > version` step in
+#   charmcraft.yaml's override-build need it.
+# - build-essential, pkg-config: some indirect deps build C extensions at
+#   `uv sync` time and need a compiler on PATH.
+apt-get update
+apt-get install -y --no-install-recommends \
+    mandoc make git build-essential pkg-config
+
+# uv hardlinks by default, which fails across the workshop mount boundary.
+echo UV_LINK_MODE=copy >> /etc/environment
+# Keep the workshop venv off the host's mounted project directory so it
+# doesn't collide with a host-side `.venv` from a parallel `make unit`.
+echo UV_PROJECT_ENVIRONMENT=/tmp/workshop-uv-venv >> /etc/environment

--- a/.workshop/manpages-dev/hooks/setup-project
+++ b/.workshop/manpages-dev/hooks/setup-project
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+sudo -i -u workshop -- bash -e << 'EOF'
+set -e
+cd /project
+
+# Install the charm's runtime + dev deps (ops[testing], pytest, ruff, ty,
+# jubilant, requests, coverage) into the workshop-isolated venv at
+# $UV_PROJECT_ENVIRONMENT.
+uv sync --all-extras
+
+# Warm the Go module cache so the first `go-test` / `build` run isn't
+# delayed pulling pault.ag/go/debian etc.
+go mod download
+EOF

--- a/.workshop/manpages-dev/sdk.yaml
+++ b/.workshop/manpages-dev/sdk.yaml
@@ -1,0 +1,11 @@
+# In-project SDK for developing the ubuntu-manpages-operator. Consumed as
+# `project-manpages-dev` from workshop.yaml. In-project SDKs have no
+# build-time features (no base/build-base/platforms/parts) — they're
+# configured entirely via the hooks under hooks/.
+#
+# Relies on the `uv` and `go` SDKs already being present in the workshop:
+# setup-base only handles OS packages (mandoc, make, git) and env vars;
+# setup-project runs `uv sync` and warms the Go module cache.
+name: manpages-dev
+version: "0"
+summary: In-project setup for developing the ubuntu-manpages-operator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,39 @@ To create the environment manually:
 ❯ uv sync --all-extras
 ```
 
+## Workshop (alternative dev environment)
+
+[Workshop](https://ubuntu.com/workshop/) provides a reproducible LXD-backed
+dev environment for this repo. Both the Go app and the Python charm build inside
+one workshop, with no need for `mandoc` on the host.
+
+```bash
+sudo snap install workshop --classic
+workshop launch                       # first run only; takes a few minutes
+workshop run lint                     # or: format, unit, go-test, pytest, static-check, build
+workshop run serve                    # run cmd/server; site at http://localhost:8080
+workshop run ingest-pkg -- -release noble -package coreutils  # single-package debug
+workshop shell                        # interactive shell inside the workshop
+```
+
+Charm packing (`charmcraft pack`), rock building (`rockcraft pack`), and the
+jubilant integration tests are deliberately not wired up as actions — they need
+nested LXD or a real Juju model. Run those on the host as usual.
+
+### Sharing build caches with the host (optional)
+
+By default the Go module cache and uv cache live inside the workshop, isolated
+from the host's `~/go/pkg/mod` and `~/.cache/uv`. To share them (useful if you
+also build on the host, or run multiple workshops) bind the SDK mount plugs to
+host paths once per workshop:
+
+```bash
+workshop remount dev/go:mod-cache ~/go/pkg/mod
+workshop remount dev/uv:cache     ~/.cache/uv
+```
+
+These connections persist across `workshop refresh` and `workshop stop`/`start`.
+
 ## Running tests
 
 Unit tests can be run locally with no additional tools by running `make unit`. All of the project's unit tests are designed to run agnostic of machine and network, and shouldn't require any additional dependencies other than those injected by `uv run` and the `Make` target.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ workshop shell                        # interactive shell inside the workshop
 ```
 
 Charm packing (`charmcraft pack`), rock building (`rockcraft pack`), and the
-jubilant integration tests are deliberately not wired up as actions — they need
+jubilant integration tests are deliberately not wired up as actions. They need
 nested LXD or a real Juju model. Run those on the host as usual.
 
 ### Sharing build caches with the host (optional)

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -17,12 +17,24 @@
 #   workshop refresh dev --sdk go=<channel>
 
 name: dev
-base: ubuntu@24.04
+base: ubuntu@26.04
 
 sdks:
   - name: go
+    slots:
+      # Forward the Go server's :8080 to the host so the rendered site is
+      # reachable in a browser without leaving the workshop. Auto-connects
+      # (plug on system, slot on a regular SDK, matching name, localhost).
+      web:
+        interface: tunnel
+        endpoint: localhost:8080
   - name: uv
   - name: project-manpages-dev  # .workshop/manpages-dev/sdk.yaml
+  - name: system
+    plugs:
+      web:
+        interface: tunnel
+        endpoint: localhost:8080
 
 actions:
   # Full lint pass: go vet + ruff check + ruff format --check + ty.
@@ -52,9 +64,34 @@ actions:
   static-check: |
     uv run --all-extras ty check src tests
 
-  # Build all three Go binaries with the same flags CI uses, into ./bin/.
-  # Confirms the codebase compiles before pushing.
+  # Build all three Go binaries with the same flags CI uses. Confirms the
+  # codebase compiles before pushing. Output goes inside the workshop, not
+  # /project/bin, to avoid clobbering host `make build` artifacts and to
+  # skip the bind-mount overhead.
   build: |
-    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/server ./cmd/server
-    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/ingest ./cmd/ingest
-    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/ingest-pkg ./cmd/ingest-pkg
+    out="${MANPAGES_BIN_DIR:-/home/workshop/bin}"
+    mkdir -p "$out"
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o "$out/server"     ./cmd/server
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o "$out/ingest"     ./cmd/ingest
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o "$out/ingest-pkg" ./cmd/ingest-pkg
+    echo "Built $out/{server,ingest,ingest-pkg}"
+
+  # Run the HTTP server. The `go:web` tunnel forwards :8080 to the host,
+  # so the site is reachable at http://localhost:8080. The server itself
+  # is quiet until a request arrives, so print a banner up front. Extra
+  # args are forwarded (currently none accepted, but kept for symmetry).
+  serve: |
+    addr="${MANPAGES_ADDR:-:8080}"
+    # The production default (/app/www) isn't writable in the workshop, and
+    # /project/www would pollute the host working tree and go through the
+    # slower bind mount. Keep ingest output inside the workshop instead;
+    # it's ephemeral test data, cleared by `workshop remove`.
+    export MANPAGES_PUBLIC_HTML_DIR="${MANPAGES_PUBLIC_HTML_DIR:-/home/workshop/www}"
+    echo "Starting manpages server on ${addr} (http://localhost${addr})"
+    go run ./cmd/server "$@"
+
+  # Single-package ingest for the dev/debug loop, e.g.:
+  #   workshop run ingest-pkg -- -release noble -package coreutils
+  ingest-pkg: |
+    export MANPAGES_PUBLIC_HTML_DIR="${MANPAGES_PUBLIC_HTML_DIR:-/home/workshop/www}"
+    go run ./cmd/ingest-pkg "$@"

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -1,0 +1,60 @@
+# Workshop definition for developing the ubuntu-manpages-operator.
+#
+# This repo contains two projects that build together:
+#   - A Go application (cmd/{server,ingest,ingest-pkg}) packaged as an OCI rock.
+#   - A Python charm (src/charm.py) deployed via Juju on Kubernetes.
+#
+# Day-to-day development covers lint, format, and unit tests for both
+# halves. Charm packing (charmcraft), rock building (rockcraft), and the
+# jubilant integration tests aren't wired up as actions here:
+#   - charmcraft pack / rockcraft pack need LXD inside the workshop (nested);
+#     a separate `lxd` SDK is the right answer but is out of scope for the
+#     initial spike.
+#   - integration tests need a real Juju model, which can't run here.
+#
+# To override the Go toolchain (e.g. when the go.mod `go` directive is bumped):
+#
+#   workshop refresh dev --sdk go=<channel>
+
+name: dev
+base: ubuntu@24.04
+
+sdks:
+  - name: go
+  - name: uv
+  - name: project-manpages-dev  # .workshop/manpages-dev/sdk.yaml
+
+actions:
+  # Full lint pass: go vet + ruff check + ruff format --check + ty.
+  lint: |
+    make lint
+
+  # Apply formatting fixes (go fmt + ruff --fix + ruff format).
+  format: |
+    make format
+
+  # Full unit test suite: go test ./... plus pytest with coverage.
+  unit: |
+    make unit
+
+  # Just the Go test suite, with the race detector. Faster than `unit` when
+  # iterating on Go code. Extra args are forwarded (e.g. `-run TestFoo`).
+  go-test: |
+    go test -race -v ./... "$@"
+
+  # Just the Python charm tests. Faster than `unit` when iterating on the
+  # charm. PYTHONPATH mirrors the Makefile so `import charm` etc. resolves.
+  pytest: |
+    PYTHONPATH=/project:/project/lib:/project/src \
+      uv run --all-extras pytest --ignore=tests/integration --tb native -v "$@"
+
+  # Type checks alone — useful as a `workshop run` watch loop target.
+  static-check: |
+    uv run --all-extras ty check src tests
+
+  # Build all three Go binaries with the same flags CI uses, into ./bin/.
+  # Confirms the codebase compiles before pushing.
+  build: |
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/server ./cmd/server
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/ingest ./cmd/ingest
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/ingest-pkg ./cmd/ingest-pkg

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -7,12 +7,10 @@
 # Day-to-day development covers lint, format, and unit tests for both
 # halves. Charm packing (charmcraft), rock building (rockcraft), and the
 # jubilant integration tests aren't wired up as actions here:
-#   - charmcraft pack / rockcraft pack need LXD inside the workshop (nested);
-#     a separate `lxd` SDK is the right answer but is out of scope for the
-#     initial spike.
+#   - charmcraft pack / rockcraft pack need LXD inside the workshop (nested).
 #   - integration tests need a real Juju model, which can't run here.
 #
-# To override the Go toolchain (e.g. when the go.mod `go` directive is bumped):
+# To override the Go toolchain (for example, when the go.mod `go` directive is bumped):
 #
 #   workshop refresh dev --sdk go=<channel>
 
@@ -90,7 +88,7 @@ actions:
     echo "Starting manpages server on ${addr} (http://localhost${addr})"
     go run ./cmd/server "$@"
 
-  # Single-package ingest for the dev/debug loop, e.g.:
+  # Single-package ingest for the dev/debug loop, for example:
   #   workshop run ingest-pkg -- -release noble -package coreutils
   ingest-pkg: |
     export MANPAGES_PUBLIC_HTML_DIR="${MANPAGES_PUBLIC_HTML_DIR:-/home/workshop/www}"


### PR DESCRIPTION
Adds a `dev` workshop definition that wraps the day-to-day developer flow for the ubuntu-manpages-operator (Go app + Python charm) in a reproducible environment.

Layout:

    workshop.yaml                                  # workshop: dev / ubuntu@26.04
    .workshop/manpages-dev/sdk.yaml                # in-project SDK metadata
    .workshop/manpages-dev/hooks/setup-base        # apt install mandoc/make/...
    .workshop/manpages-dev/hooks/setup-project     # uv sync + go mod download
    .workshop/manpages-dev/hooks/check-health      # gate readiness for actions

Actions cover the targets a developer runs locally:

    lint          go vet + ruff + ty
    format        go fmt + ruff fixes
    unit          full unit suite (Go + Python with coverage)
    go-test       Go suite alone, with -race
    pytest        Python charm tests alone
    static-check  ty alone
    build         compile all three Go binaries (output: /home/workshop/bin)
    serve         run cmd/server; exposed at http://localhost:8080 via tunnel
    ingest-pkg    single-package ingest for dev/debug (output: /home/workshop/www)

The `web` tunnel is set up between the `system` SDK and the `go` SDK so the server's `:8080` auto-forwards to the host — `workshop run serve` then `curl localhost:8080` Just Works.

Build and ingest output live inside the workshop (`/home/workshop/{bin,www}`), not under `/project/`, so the host working tree stays clean and writes skip the bind mount.

The `check-health` hook reports the specific failure (missing tool vs broken charm venv) so users know whether to refresh or investigate.

Not included as actions: `charmcraft pack`, `rockcraft pack`, and the jubilant integration tests (juju + LXD).

Verified end-to-end against a clean workshop:

- [x] `workshop remove dev` → `workshop launch dev` → status `ready`, no warnings
- [x] `workshop stop dev` → `workshop start dev` → status `ready`
- [x] All actions run cleanly: `build`, `lint`, `format`, `static-check`, `pytest`, `go-test`, `unit`, `ingest-pkg`, `serve`
- [x] `serve` reachable on host at `http://localhost:8080` via the auto-connected `web` tunnel (`/healthz` → `{"status":"ok"}`, `/` → 200)
- [x] `ingest-pkg -release noble -package coreutils` → 106 manpages, 0 convert errors, output at `/home/workshop/www`
