### PR TITLE
ci: use test rock resource in spread

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -83,7 +83,6 @@ jobs:
         if: ${{ inputs.publish }}
         id: get_version
         run: |
-          sudo snap install yq --classic
           version="$(yq '.version' rockcraft.yaml)"
           echo "VERSION=$version" >> $GITHUB_OUTPUT
 
@@ -130,11 +129,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-wheel-cache-
       
-      - name: Update charm to use test Rock
-        if: ${{ !inputs.publish }}
-        run: |
-          yq -i '.resources.manpages-image.upstream-source = "ttl.sh/ubuntu-manpages-${{ github.run_id }}:2h"' charmcraft.yaml
-
       - name: Pack charm
         run: charmcraft pack -v
 
@@ -190,6 +184,11 @@ jobs:
 
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
+
+      - name: Configure test ROCK resource
+        if: ${{ !inputs.publish }}
+        run: |
+          yq -i '.resources.manpages-image.upstream-source = "ttl.sh/ubuntu-manpages-${{ github.run_id }}:2h"' charmcraft.yaml
 
       - name: Run integration tests
         run: |


### PR DESCRIPTION
## Summary
- move the PR ttl.sh `upstream-source` rewrite from charm packing to the spread test checkout
- keep charm packing independent of `upstream-source`, which charmcraft ignores
- ensure integration fixtures read `ttl.sh/ubuntu-manpages-${{ github.run_id }}:2h` during PR spread runs
- stop installing `yq`; it is available in the GitHub runner base image

## Rationale
The integration fixtures read `charmcraft.yaml` from the spread checkout to decide which OCI image resource to pass to Juju. Rewriting `upstream-source` in the charm build job does not affect that fresh checkout, so the rewrite needs to happen immediately before `charmcraft.spread`.

## Test plan
- `git diff --check`
- Parsed workflow YAML with PyYAML
- Verified no workflow still installs `yq`; it uses the runner-provided binary
- Not run locally.
