### PR TITLE
ci: checkout before charm promotion

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -7,6 +7,9 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Promote snap to stable
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add an explicit checkout step before running `charmcraft promote` in the manual promote workflow.
- Fixes the workflow failure where charmcraft runs without repository metadata checked out.

## Test Plan
- Parsed `.github/workflows/promote.yaml` with PyYAML and asserted checkout precedes promote.
- `git diff --check`

Note: `actionlint` was not installed locally, so workflow linting with actionlint was skipped.
