### PR TITLE
fix(fetcher): accept package checksums other than SHA1 (#78)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ internal/             # Go internal packages
   pipeline/           #   Orchestrates extraction, conversion, transformation, and storage
   search/             #   In-memory indexed manpage search (with fuzzy matching via Damerau-Levenshtein)
   sitemap/            #   XML sitemap generation
-  storage/            #   Filesystem-based HTML/gzip storage with per-package SHA1 cache
+  storage/            #   Filesystem-based HTML/gzip storage with a per-package checksum cache
   transform/          #   8-stage HTML transformation pipeline (mandoc output → web-ready HTML)
   web/                #   HTTP server, routes, templates, static assets
     templates/        #   Go html/template files (base, base-landing, head, nav, footer, search-form, index, manpage, browse, search, 404)
@@ -91,20 +91,20 @@ The `server` and `ingest` binaries have no CLI flags — all configuration comes
 | `MANPAGES_ARCH`            | `amd64`                                                  | Architecture to fetch packages for                     |
 | `MANPAGES_ADDR`            | `:8080`                                                  | HTTP bind address (server only)                        |
 | `MANPAGES_LOG_LEVEL`       | `info`                                                   | Log level (debug, info, warn, error)                   |
-| `MANPAGES_FORCE`           | `false`                                                  | Force reprocessing of all packages (ignore SHA1 cache) |
+| `MANPAGES_FORCE`           | `false`                                                  | Force reprocessing of all packages (ignore checksum cache) |
 
 ### Ingest Pipeline
 
 For each release (processed concurrently):
 
 1. **Fetch** `Packages.gz` index files from the archive (across pockets: base, `-updates`, `-security`), deduplicate by highest version.
-2. **Per package**: check SHA1 cache → download `.deb` → extract manpages → for each manpage:
+2. **Per package**: check checksum cache → download `.deb` → extract manpages → for each manpage:
    - Parse the path to determine output location.
    - Handle symlinks and `.so` references.
    - Convert roff → HTML using `mandoc`.
    - Run 8-stage HTML transform pipeline (rewrite links, extract title, structure headings, generate TOC, inject metadata).
    - Write HTML and gzip outputs to the filesystem.
-   - Update SHA1 cache so unchanged packages are skipped on the next run.
+   - Update checksum cache so unchanged packages are skipped on the next run.
 3. **Generate sitemaps** per release/section.
 
 Failures are non-fatal per manpage — errors are logged and counted. A summary is printed at the end.
@@ -161,7 +161,7 @@ cp .env.example .env   # edit as needed
 # Ingest a subset of releases
 MANPAGES_RELEASES=noble ./bin/ingest
 
-# Force reprocessing (ignore SHA1 cache)
+# Force reprocessing (ignore checksum cache)
 MANPAGES_FORCE=true ./bin/ingest
 
 # Ingest a single package (for debugging)
@@ -249,7 +249,7 @@ All JavaScript in `internal/web/static/` uses modern ES6/7 syntax:
 
 ## Key Design Decisions
 
-- **No database**: Storage is filesystem-based — the generated HTML tree _is_ the data store, with SHA1 files as the package cache. Search uses an in-memory filename index built at startup by scanning the HTML tree; no external search engine or database is needed.
+- **No database**: Storage is filesystem-based — the generated HTML tree _is_ the data store, with checksum files as the package cache. Search uses an in-memory filename index built at startup by scanning the HTML tree; no external search engine or database is needed.
 - **Two-service model**: The server runs continuously; the ingestion process runs once and exits. Pebble's `on-success: ignore` prevents the charm from restarting it after completion.
 - **mandoc for conversion**: The `mandoc` utility converts roff to HTML. It's installed as a stage package in the rock.
 - **8-stage HTML pipeline**: Raw `mandoc` output is transformed through multiple stages to produce web-ready HTML with proper links, TOC, metadata, and structure.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ All three binaries read configuration from environment variables, optionally loa
 | `MANPAGES_ADDR`            | `:8080`                                                  | HTTP bind address (server only)                        |
 | `MANPAGES_ADMIN_ADDR`      | `127.0.0.1:9090`                                         | Admin listener address for internal endpoints; must be loopback-only (server only) |
 | `MANPAGES_LOG_LEVEL`       | `info`                                                   | Log level (debug, info, warn, error)                   |
-| `MANPAGES_FORCE`           | `false`                                                  | Force reprocessing of all packages (ignore SHA1 cache) |
+| `MANPAGES_FORCE`           | `false`                                                  | Force reprocessing of all packages (ignore checksum cache) |
 
 ### Ingest pipeline
 
-For each configured release (processed concurrently), the ingest binary fetches `Packages.gz` index files from the Ubuntu archive, deduplicates packages by highest version, and downloads each `.deb` that has changed since the last run (based on a SHA1 cache). Manpages are extracted from each package, converted from roff to HTML using `mandoc`, and run through an 8-stage HTML transform pipeline that rewrites links, extracts titles, generates a table of contents, and injects metadata. Finally, sitemaps are generated per release and section.
+For each configured release (processed concurrently), the ingest binary fetches `Packages.gz` index files from the Ubuntu archive, deduplicates packages by highest version, and downloads each `.deb` that has changed since the last run (based on a per-package checksum cache, using whichever checksum field—SHA256, SHA1, SHA512, or MD5sum—the archive publishes). Manpages are extracted from each package, converted from roff to HTML using `mandoc`, and run through an 8-stage HTML transform pipeline that rewrites links, extracts titles, generates a table of contents, and injects metadata. Finally, sitemaps are generated per release and section.
 
 ### Web server
 
@@ -46,7 +46,7 @@ The server binary serves the generated HTML manpages along with search, browse, 
 
 ### Key design decisions
 
-- **No database** — Both storage and search are filesystem-based. The generated HTML tree _is_ the data store, with SHA1 files as the package cache.
+- **No database** — Both storage and search are filesystem-based. The generated HTML tree _is_ the data store, with checksum files as the package cache.
 - **Fuzzy search** — Search matches in four tiers: exact, prefix, substring (contains), and fuzzy (Damerau-Levenshtein distance). Fuzzy results are shown in a separate "Similar matches" section so typos like `grpe` still find `grep`. The JSON API exposes the `match_type` field on each result.
 - **mandoc for conversion** — The `mandoc` utility converts roff to HTML. It is installed as a stage package in the OCI image.
 - **Metadata in HTML comments** — Each generated manpage embeds a `<!--META:{...}-->` JSON comment containing title, description, package info, and TOC. The server parses this at serve time for rendering and search enrichment.

--- a/cmd/ingest-pkg/main.go
+++ b/cmd/ingest-pkg/main.go
@@ -121,8 +121,8 @@ func run(logger *slog.Logger, cfg *config.Config, release, pkgName string) error
 	}
 
 	// Write cache so subsequent full ingests see this package as processed.
-	if pkg.SHA1 != "" {
-		if err := storage.WriteCache(ctx, release, pkg.Name, pkg.SHA1); err != nil {
+	if pkg.Hash != "" {
+		if err := storage.WriteCache(ctx, release, pkg.Name, pkg.Hash); err != nil {
 			return fmt.Errorf("write cache: %w", err)
 		}
 	}

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -22,7 +22,11 @@ type Package struct {
 	Name     string
 	Version  string
 	Filename string
-	SHA1     string
+	// Hash is a checksum fingerprint used to detect package changes for
+	// caching purposes. It is populated from whichever checksum field the
+	// archive publishes (archives don't always publish all of them; e.g.
+	// some releases only publish SHA512).
+	Hash string
 }
 
 type Fetcher struct {
@@ -317,7 +321,23 @@ func parsePackages(reader io.Reader) ([]Package, error) {
 	var results []Package
 
 	flush := func() {
-		if fields["Package"] == "" || fields["Filename"] == "" || fields["SHA1"] == "" {
+		// Prefer the strongest checksum available, falling back to
+		// weaker ones: some releases only publish a subset of checksum
+		// fields (e.g. SHA512 only). The hash is only ever used as an
+		// opaque change-detection fingerprint, but preferring the
+		// strongest available one minimises the (already tiny) risk of
+		// collisions masking a real package change.
+		hash := fields["SHA512"]
+		if hash == "" {
+			hash = fields["SHA256"]
+		}
+		if hash == "" {
+			hash = fields["SHA1"]
+		}
+		if hash == "" {
+			hash = fields["MD5sum"]
+		}
+		if fields["Package"] == "" || fields["Filename"] == "" || hash == "" {
 			fields = map[string]string{}
 			return
 		}
@@ -325,7 +345,7 @@ func parsePackages(reader io.Reader) ([]Package, error) {
 			Name:     fields["Package"],
 			Version:  fields["Version"],
 			Filename: fields["Filename"],
-			SHA1:     fields["SHA1"],
+			Hash:     hash,
 		})
 		fields = map[string]string{}
 	}
@@ -342,7 +362,7 @@ func parsePackages(reader io.Reader) ([]Package, error) {
 		}
 		key, value := parts[0], parts[1]
 		switch key {
-		case "Package", "Version", "Filename", "SHA1":
+		case "Package", "Version", "Filename", "SHA1", "SHA256", "SHA512", "MD5sum":
 			fields[key] = value
 		}
 	}

--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -8,10 +8,64 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestParsePackages_HashFallback(t *testing.T) {
+	// Some archives (e.g. newer Ubuntu releases) only publish a subset of
+	// checksum fields. parsePackages must not silently drop packages that
+	// lack SHA1 as long as some checksum is present, and must prefer
+	// SHA512 over SHA256 over SHA1 over MD5sum when several are present.
+	input := "Package: sha512-only\n" +
+		"Version: 1.0-1\n" +
+		"Filename: pool/s/sha512-only.deb\n" +
+		"SHA512: deadbeef\n" +
+		"\n" +
+		"Package: sha1-and-sha256\n" +
+		"Version: 1.0-1\n" +
+		"Filename: pool/s/sha1-and-sha256.deb\n" +
+		"SHA1: aaa\n" +
+		"SHA256: bbb\n" +
+		"\n" +
+		"Package: all-hashes\n" +
+		"Version: 1.0-1\n" +
+		"Filename: pool/a/all-hashes.deb\n" +
+		"MD5sum: ccc\n" +
+		"SHA1: ddd\n" +
+		"SHA256: eee\n" +
+		"SHA512: fff\n" +
+		"\n" +
+		"Package: no-checksum\n" +
+		"Version: 1.0-1\n" +
+		"Filename: pool/n/no-checksum.deb\n" +
+		"\n"
+
+	got, err := parsePackages(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parsePackages: %v", err)
+	}
+
+	want := map[string]string{
+		"sha512-only":     "deadbeef",
+		"sha1-and-sha256": "bbb",
+		"all-hashes":      "fff",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d packages (no-checksum should be dropped), got %d: %+v", len(want), len(got), got)
+	}
+	for _, pkg := range got {
+		hash, ok := want[pkg.Name]
+		if !ok {
+			t.Fatalf("unexpected package %q in results", pkg.Name)
+		}
+		if pkg.Hash != hash {
+			t.Errorf("package %q: expected hash %q, got %q", pkg.Name, hash, pkg.Hash)
+		}
+	}
+}
 
 func TestFetchDeb_RetriesOnConnectionReset(t *testing.T) {
 	var attempts atomic.Int32
@@ -94,11 +148,11 @@ func TestFetchDeb_FailsAfterAllRetries(t *testing.T) {
 func TestFetchPackages_RetriesOnConnectionReset(t *testing.T) {
 	var attempts atomic.Int32
 
-	entries := []Package{{Name: "foo", Version: "1.0-1", Filename: "pool/f/foo.deb", SHA1: "aaa"}}
+	entries := []Package{{Name: "foo", Version: "1.0-1", Filename: "pool/f/foo.deb", Hash: "aaa"}}
 	var body bytes.Buffer
 	for _, p := range entries {
 		fmt.Fprintf(&body, "Package: %s\nVersion: %s\nFilename: %s\nSHA1: %s\n\n",
-			p.Name, p.Version, p.Filename, p.SHA1)
+			p.Name, p.Version, p.Filename, p.Hash)
 	}
 	var gz bytes.Buffer
 	gw := gzip.NewWriter(&gz)
@@ -219,7 +273,7 @@ func TestFetchPackagesParallel(t *testing.T) {
 		var buf bytes.Buffer
 		for _, p := range entries {
 			fmt.Fprintf(&buf, "Package: %s\nVersion: %s\nFilename: %s\nSHA1: %s\n\n",
-				p.Name, p.Version, p.Filename, p.SHA1)
+				p.Name, p.Version, p.Filename, p.Hash)
 		}
 		var gz bytes.Buffer
 		w := gzip.NewWriter(&gz)
@@ -230,12 +284,12 @@ func TestFetchPackagesParallel(t *testing.T) {
 
 	// Two "pockets" serve overlapping packages with different versions.
 	pocket1 := makePackagesGz([]Package{
-		{Name: "foo", Version: "2.0-1", Filename: "pool/f/foo_2.deb", SHA1: "aaa"},
-		{Name: "bar", Version: "1.0-1", Filename: "pool/b/bar_1.deb", SHA1: "bbb"},
+		{Name: "foo", Version: "2.0-1", Filename: "pool/f/foo_2.deb", Hash: "aaa"},
+		{Name: "bar", Version: "1.0-1", Filename: "pool/b/bar_1.deb", Hash: "bbb"},
 	})
 	pocket2 := makePackagesGz([]Package{
-		{Name: "foo", Version: "1.0-1", Filename: "pool/f/foo_1.deb", SHA1: "ccc"},
-		{Name: "baz", Version: "3.0-1", Filename: "pool/b/baz_3.deb", SHA1: "ddd"},
+		{Name: "foo", Version: "1.0-1", Filename: "pool/f/foo_1.deb", Hash: "ccc"},
+		{Name: "baz", Version: "3.0-1", Filename: "pool/b/baz_3.deb", Hash: "ddd"},
 	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -156,8 +156,8 @@ func (r *Runner) processPackage(ctx context.Context, idx int, release string, pk
 		r.Logger.Info("processing package", "release", release, "package", pkg.Name)
 	}
 
-	if !r.ForceProcess && pkg.Name != "" && pkg.SHA1 != "" {
-		if r.Storage.CheckCache(release, pkg.Name, pkg.SHA1) {
+	if !r.ForceProcess && pkg.Name != "" && pkg.Hash != "" {
+		if r.Storage.CheckCache(release, pkg.Name, pkg.Hash) {
 			if r.Logger != nil {
 				r.Logger.Debug("skipping unchanged package", "release", release, "package", pkg.Name)
 			}
@@ -186,8 +186,8 @@ func (r *Runner) processPackage(ctx context.Context, idx int, release string, pk
 		}
 	}
 
-	if pkg.Name != "" && pkg.SHA1 != "" {
-		if err := r.Storage.WriteCache(ctx, release, pkg.Name, pkg.SHA1); err != nil {
+	if pkg.Name != "" && pkg.Hash != "" {
+		if err := r.Storage.WriteCache(ctx, release, pkg.Name, pkg.Hash); err != nil {
 			return fmt.Errorf("write cache for %s: %w", pkg.Name, err)
 		}
 	}


### PR DESCRIPTION
Packages.gz without a SHA1 information (e.g. the "stonking" release, which only publishes SHA512) were silently dropped during parsing, resulting in zero packages being ingested for that release and an empty manpages tree being served.

Rename Package.SHA1 to Package.Hash and populate it from whichever checksum info the archive actually publishes, preferring the strongest available one: SHA512 > SHA256 > SHA1
> MD5sum. Update callers and tests accordingly, and adjust
documentation wording from "SHA1 cache" to "checksum cache".